### PR TITLE
Added text crawler and gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+*.DS_STORE

--- a/TextCrawler/content_script.js
+++ b/TextCrawler/content_script.js
@@ -1,0 +1,34 @@
+walk(document.body);
+
+function walk(node)
+{
+    // stolen from someone much smarter than me: @panicsteve
+    var child, next;
+    if(node.tagName !== undefined && (node.tagName.toLowerCase() == 'input' 
+    || node.tagName.toLowerCase() == 'textarea' 
+    || node.classList.contains('ace_editor'))) { // wtf is ace_editor?
+        return;
+    } 
+
+    switch(node.nodeType){
+        case 1: // element
+        case 9: // document
+        case 11: // document fragment
+            child = node.firstChild;
+            while(child) {
+                next = child.nextSibling;
+                walk(child);
+                child = next;
+            }
+            break;
+        case 3: // text node
+            handleText(node);
+    }
+}
+
+function handleText(textNode) {
+    var v = textNode.nodeValue;
+    v = v.replace(/\bthe\b/gi, "Insik");
+
+    textNode.nodeValue = v;
+}

--- a/TextCrawler/manifest.json
+++ b/TextCrawler/manifest.json
@@ -1,0 +1,13 @@
+{
+    "manifest_version": 2,
+    "name": "Basic Word Replacement",
+    "description": "Me fooling around with word replacement chrome extensions.",
+    "version": "1.0",
+    "content_scripts":
+    [
+        {
+            "matches": ["*://*/*"],
+            "js": ["content_script.js"]
+        }
+    ]
+}


### PR DESCRIPTION
Added outline for a basic text crawling extension.

For extra specification, in the manifest.json file when specifying the script, you could add a parameter "run_at" with a value of "document_end". By default, the script is run at "document_idle".

For more, see the docs here and control-F for "run_at": https://developer.chrome.com/extensions/content_scripts
